### PR TITLE
Fix issue with ssh priv key

### DIFF
--- a/show-all-credentials.groovy
+++ b/show-all-credentials.groovy
@@ -21,7 +21,7 @@ credentialsStore?.getCredentials(domain).each{
   if(it instanceof UsernamePasswordCredentialsImpl)
     showRow("user/password", it.id, it.username, it.password?.getPlainText(), it.description)
   else if(it instanceof BasicSSHUserPrivateKey)
-    showRow("ssh priv key", it.id, it.passphrase?.getPlainText(), it.privateKeySource?.getPrivateKey(), it.description)
+    showRow("ssh priv key", it.id, it.passphrase?.getPlainText(), it.privateKeySource?.getPrivateKey()?.getPlainText(), it.description)
   else if(it instanceof AWSCredentialsImpl)
     showRow("aws", it.id, it.accessKey, it.secretKey?.getPlainText(), it.description)
   else if(it instanceof StringCredentials)


### PR DESCRIPTION
Hi @tavogel  

Since [ssh-credentials-plugin-1.16](https://github.com/jenkinsci/ssh-credentials-plugin/blob/master/CHANGELOG.md#version-116-apr-22-2019), [com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey.DirectEntryPrivateKeySource.getPrivateKey](https://github.com/jenkinsci/ssh-credentials-plugin/commit/580f9805474bbfd257bd99aac2345e19853400bd#diff-1d109e1e8cfd6c562d65c82eac98a20b8ef4091bfc631a560a50a39db7b232b2) method returns a Secret instead of a String, which breaks your script when [showRow is called to display BasicSSHUserPrivateKey object content](https://github.com/tkrzeminski/jenkins-groovy-scripts/blob/2f8b67aaf9eeabc2bd66afc4678ee05473d9dc47/show-all-credentials.groovy#L24).