### PR TITLE
Add new credentials kind - Be generic

### DIFF
--- a/show-all-credentials.groovy
+++ b/show-all-credentials.groovy
@@ -19,7 +19,7 @@ credentialsStore?.getCredentials(domain).each{
       showRow("user/password", it.id, it?.username, it?.password?.plainText, it.description)
       break
     case "com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey":
-      showRow("ssh priv key", it.id, it.privateKeySource?.privateKey?.plainText, it.passphrase.decrypt()?:"", it.description)
+      showRow("ssh priv key", it.id, it.privateKeySource?.privateKey?.plainText, it.passphrase?.decrypt()?:"", it.description)
       break
     case "com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl":
       showRow("aws", it.id, it.accessKey, it.secretKey?.plainText, it.description)

--- a/show-all-credentials.groovy
+++ b/show-all-credentials.groovy
@@ -1,11 +1,6 @@
 import jenkins.model.*
 import com.cloudbees.plugins.credentials.*
-import com.cloudbees.plugins.credentials.impl.*
 import com.cloudbees.plugins.credentials.domains.*
-import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey
-import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl
-import org.jenkinsci.plugins.plaincredentials.StringCredentials
-import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl
 
 def showRow = { credentialType, secretId, username = null, password = null, description = null ->
   println("${credentialType} : ".padLeft(20) + secretId?.padRight(38)+" | " +username?.padRight(20)+" | " +password?.padRight(40) + " | " +description)
@@ -18,18 +13,33 @@ credentialsStore = Jenkins.instance.getExtensionList('com.cloudbees.plugins.cred
 domain = new Domain(domainName, null, Collections.<DomainSpecification>emptyList())
 
 credentialsStore?.getCredentials(domain).each{
-  if(it instanceof UsernamePasswordCredentialsImpl)
-    showRow("user/password", it.id, it.username, it.password?.getPlainText(), it.description)
-  else if(it instanceof BasicSSHUserPrivateKey)
-    showRow("ssh priv key", it.id, it.passphrase?.getPlainText(), it.privateKeySource?.getPrivateKey()?.getPlainText(), it.description)
-  else if(it instanceof AWSCredentialsImpl)
-    showRow("aws", it.id, it.accessKey, it.secretKey?.getPlainText(), it.description)
-  else if(it instanceof StringCredentials)
-    showRow("secret text", it.id, it.secret?.getPlainText(), '', it.description)
-  else if(it instanceof FileCredentialsImpl)
-    showRow("secret file", it.id, it.content?.text, '', it.description)
-  else
-    showRow("something else", it.id, '', '', '')
+  switch(it.class.name) {
+    case "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl":
+      println it.password.class.name
+      showRow("user/password", it.id, it?.username, it?.password?.plainText, it.description)
+      break
+    case "com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey":
+      showRow("ssh priv key", it.id, it.privateKeySource?.privateKey?.plainText, it.passphrase.decrypt()?:"", it.description)
+      break
+    case "com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl":
+      showRow("aws", it.id, it.accessKey, it.secretKey?.plainText, it.description)
+      break
+    case "org.jenkinsci.plugins.plaincredentials.StringCredentials":
+      showRow("secret text", it.id, it.secret?.plainText, '', it.description)
+      break
+    case "org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl":
+      showRow("secret file", it.id, it.content?.text, '', it.description)
+      break
+    case "com.microsoft.azure.util.AzureCredentials":
+      showRow("azur", it.id, it?.subscriptionId, "${it?.clientId}:${hudson.util.Secret.decrypt(it?.clientSecret)}", it.description)
+      break
+    case "org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials":      
+      showRow("docker", it.id, it.clientCertificate, it?.clientKey, it.description)
+      break
+    default:
+      showRow("something else", it.id, it.class.name, '', it.description)
+      break
+  }
 }
 
 return


### PR DESCRIPTION
**New credentials kind:**
* Azur
* Docker client certificate

**Be generic :** 
Previous implementation required related credentials plugins to be installed on instance where script was run.
By relying on class name instead of `instanceof` script can be run as this on any instance whatever credentials plugins is installed